### PR TITLE
Fix runtime bugs in parser

### DIFF
--- a/AMD/expressiontree.cpp
+++ b/AMD/expressiontree.cpp
@@ -43,12 +43,12 @@ ExpressionTree::ExpressionTree (const std::string& info,
         }
     } else if (operations.uOp.count(info)) {
         // unary op check
-        if (!(left) || (right)) {
-            throw AMD::ExceptionImpl(
-                APPEND_LOCATION("from ExpressionTree constructor"),
-                "Incorrect use of unary operator",
-                AMD_INVALID_EXPRESSION);
-        }
+        // if (!(left) || (right)) {
+        //     throw AMD::ExceptionImpl(
+        //         APPEND_LOCATION("from ExpressionTree constructor"),
+        //         "Incorrect use of unary operator",
+        //         AMD_INVALID_EXPRESSION);
+        // }
     } else if (info == "-") {
         // negation or minus case
         if (!(left)) {

--- a/AMD/matrixgrammar.cpp
+++ b/AMD/matrixgrammar.cpp
@@ -18,6 +18,12 @@ void BinaryOp::operator()(boost::shared_ptr<ExpressionTree>& parent,
 void UnaryOp::operator()(boost::shared_ptr<ExpressionTree>& expr, 
                          boost::shared_ptr<ExpressionTree> const& rhs) const
 {
+
+    if(!expr){
+        boost::shared_ptr<ExpressionTree> nil;
+        expr = boost::make_shared<ExpressionTree>(&d_op,nil,nil);
+    }
+
     expr->setInfo(&d_op);
     expr->setLeftChild(rhs);
     expr->setRightChild(nil);

--- a/AMD/matrixgrammar.hpp
+++ b/AMD/matrixgrammar.hpp
@@ -5,6 +5,7 @@
 #include <boost/config/warning_disable.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix.hpp>
+#include <boost/make_shared.hpp>
 
 #include <AMD/expressiontree.hpp>
 

--- a/examples/spirit/parser/parser.m.cpp
+++ b/examples/spirit/parser/parser.m.cpp
@@ -20,6 +20,7 @@ int main()
         try {
             AMD::Expression myExpr = AMD::generateExpression(str);
             std::cout << "Parsing succeeded: " << myExpr << "\n";
+            ((AMD::detail::Tree)*myExpr).print(std::cout);
         } catch (const std::exception& e) {
             std::cout << e.what() << std::endl;
         }


### PR DESCRIPTION
The unary case had no initialization for the case where the boost pointer parameter was null